### PR TITLE
Fix non-deterministic language detection with BTreeSet and fancy-regex

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -62,6 +62,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
 name = "clap"
 version = "4.5.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -114,6 +129,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
+name = "fancy-regex"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72cf461f865c862bb7dc573f643dd6a2b6842f7c30b07882b56bd148cc2761b8"
+dependencies = [
+ "bit-set",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -152,9 +178,9 @@ name = "linguist"
 version = "0.1.7"
 dependencies = [
  "clap",
+ "fancy-regex",
  "linguist-types",
  "once_cell",
- "regex",
  "serde",
  "serde_json",
  "serde_yaml_ng",
@@ -201,18 +227,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a338cc41d27e6cc6dce6cefc13a0729dfbb81c262b1f519331575dd80ef3067f"
 dependencies = [
  "proc-macro2",
-]
-
-[[package]]
-name = "regex"
-version = "1.12.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843bc0191f75f3e22651ae5f1e72939ab2f72a4bc30fa80a066bd66edefc24d4"
-dependencies = [
- "aho-corasick",
- "memchr",
- "regex-automata",
- "regex-syntax",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ serde = { version = "1", features = ["derive"] }
 serde_yaml_ng = "0.10"
 once_cell = "1"
 serde_json = "1"
-regex = "1"
+fancy-regex = "0.17"
 clap = { version = "4", features = ["derive"] }
 
 [build-dependencies]

--- a/definitions/heuristics.yml
+++ b/definitions/heuristics.yml
@@ -977,7 +977,7 @@ disambiguations:
     pattern: |-
       (?x)\A
       \[
-      (?<version>
+      (?:
         (?:
           [Aa]d[Bb]lock
           (?:[ \t][Pp]lus)?
@@ -991,7 +991,16 @@ disambiguations:
       )
       (?:
         [ \t]?;[ \t]?
-        \g<version>
+        (?:
+          [Aa]d[Bb]lock
+          (?:[ \t][Pp]lus)?
+          |
+          u[Bb]lock
+          (?:[ \t][Oo]rigin)?
+          |
+          [Aa]d[Gg]uard
+        )
+        (?:[ \t] \d+(?:\.\d+)*+)?
       )*+
       \]
     # HACK: This is a contrived use of heuristics needed to address

--- a/src/indexed.rs
+++ b/src/indexed.rs
@@ -1,7 +1,7 @@
 use crate::definitions;
 use linguist_types::Disambiguation;
 use once_cell::sync::Lazy;
-use regex::Regex;
+use fancy_regex::Regex;
 use std::collections::{BTreeSet, HashMap};
 
 //

--- a/src/indexed.rs
+++ b/src/indexed.rs
@@ -2,7 +2,7 @@ use crate::definitions;
 use linguist_types::Disambiguation;
 use once_cell::sync::Lazy;
 use regex::Regex;
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeSet, HashMap};
 
 //
 // Indexed structures for faster lookups etc
@@ -12,7 +12,7 @@ pub type Filename = String;
 pub type Extension = String;
 pub type LanguageName = String;
 
-pub static LANGUAGES_BY_FILENAME: Lazy<HashMap<Filename, HashSet<LanguageName>>> =
+pub static LANGUAGES_BY_FILENAME: Lazy<HashMap<Filename, BTreeSet<LanguageName>>> =
     Lazy::new(|| {
         // Process the LANGUAGES struct, building up the index
         //
@@ -23,7 +23,7 @@ pub static LANGUAGES_BY_FILENAME: Lazy<HashMap<Filename, HashSet<LanguageName>>>
                 for filename in filenames {
                     index
                         .entry(filename.clone())
-                        .or_insert_with(HashSet::new)
+                        .or_insert_with(BTreeSet::new)
                         .insert(lang_name.clone());
                 }
             }
@@ -32,7 +32,7 @@ pub static LANGUAGES_BY_FILENAME: Lazy<HashMap<Filename, HashSet<LanguageName>>>
         index
     });
 
-pub static LANGUAGES_BY_EXTENSION: Lazy<HashMap<Extension, HashSet<LanguageName>>> =
+pub static LANGUAGES_BY_EXTENSION: Lazy<HashMap<Extension, BTreeSet<LanguageName>>> =
     Lazy::new(|| {
         // Process the LANGUAGES struct, building up the index
         //
@@ -43,7 +43,7 @@ pub static LANGUAGES_BY_EXTENSION: Lazy<HashMap<Extension, HashSet<LanguageName>
                 for extension in extensions {
                     index
                         .entry(extension.clone())
-                        .or_insert_with(HashSet::new)
+                        .or_insert_with(BTreeSet::new)
                         .insert(lang_name.clone());
                 }
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -303,5 +303,5 @@ pub fn is_vendored<P: AsRef<Path>>(filepath: P) -> Result<bool> {
     //
     Ok(indexed::VENDOR_PATTERNS
         .iter()
-        .any(|regex| regex.is_match(path_str)))
+        .any(|regex| regex.is_match(path_str).unwrap_or(false)))
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -87,13 +87,13 @@ pub fn extract_extensions(filename: &str) -> Vec<String> {
 /// ```
 pub fn matches_pattern(patterns: &[String], content: &str) -> Result<bool> {
     for pattern in patterns {
-        let regex = regex::RegexBuilder::new(pattern)
-            .multi_line(true) // Enable multiline mode so ^ matches start of any line
+        let regex = match regex::RegexBuilder::new(pattern)
+            .multi_line(true)
             .build()
-            .map_err(|e| LinguistError::InvalidRegex {
-                pattern: pattern.clone(),
-                error: e.to_string(),
-            })?;
+        {
+            Ok(r) => r,
+            Err(_) => continue,
+        };
 
         if regex.is_match(content) {
             return Ok(true);

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -87,15 +87,15 @@ pub fn extract_extensions(filename: &str) -> Vec<String> {
 /// ```
 pub fn matches_pattern(patterns: &[String], content: &str) -> Result<bool> {
     for pattern in patterns {
-        let regex = match regex::RegexBuilder::new(pattern)
+        let regex = fancy_regex::RegexBuilder::new(pattern)
             .multi_line(true)
             .build()
-        {
-            Ok(r) => r,
-            Err(_) => continue,
-        };
+            .map_err(|e| LinguistError::InvalidRegex {
+                pattern: pattern.clone(),
+                error: e.to_string(),
+            })?;
 
-        if regex.is_match(content) {
+        if regex.is_match(content).unwrap_or(false) {
             return Ok(true);
         }
     }

--- a/tests/by_extension.rs
+++ b/tests/by_extension.rs
@@ -114,6 +114,24 @@ mod test_detection_by_extension {
     }
 
     #[test]
+    fn txt_extension_is_deterministic() {
+        // .txt matches multiple languages (Adblock Filter List, Text, Vim Help File).
+        // With BTreeSet, order is always alphabetical. With HashSet, order varies
+        // per process due to random hash seeds — run this test in a shell loop
+        // across multiple processes to catch non-determinism.
+        let names: Vec<&str> = detect_language_by_extension("test.txt")
+            .unwrap()
+            .iter()
+            .map(|l| l.name)
+            .collect();
+        assert_eq!(
+            names,
+            vec!["Adblock Filter List", "Text", "Vim Help File"],
+            "languages should be in alphabetical order"
+        );
+    }
+
+    #[test]
     fn returns_language_objects() {
         // Verify we get full Language objects with metadata
         let langs = detect_language_by_extension("script.py").expect("Should not error");

--- a/tests/disambiguate.rs
+++ b/tests/disambiguate.rs
@@ -272,6 +272,37 @@ namespace cicada.data.Repository
     }
 
     #[test]
+    fn txt_plain_text_resolves_to_text() {
+        // .txt is ambiguous (Adblock Filter List, Text, Vim Help File).
+        // Plain English content should fall through all specific rules
+        // and hit the catch-all "Text" rule.
+        assert_disambiguates(
+            "notes.txt",
+            "The quick brown fox jumps over the lazy dog.",
+            "Text",
+        );
+    }
+
+    #[test]
+    fn txt_adblock_content_resolves_to_adblock() {
+        assert_disambiguates(
+            "filters.txt",
+            "[Adblock Plus 2.0]\n||example.com^\n@@||example.org^\n",
+            "Adblock Filter List",
+        );
+    }
+
+    #[test]
+    fn txt_vim_help_resolves_to_vim_help_file() {
+        // Content with a vim modeline specifying filetype=help
+        assert_disambiguates(
+            "help.txt",
+            "Some help text\n vim:tw=78:ts=8:ft=help:norl:\n",
+            "Vim Help File",
+        );
+    }
+
+    #[test]
     fn detect_csharp_with_large_comment_block() {
         // Test C# file that starts with a large comment block but has using statements later
         // This tests the behavior you were concerned about - the ^ in regex patterns


### PR DESCRIPTION
HashSet<LanguageName> in indexed.rs uses random hash seeds per process, causing detect_language_by_extension to return languages in different order each run. For extensions like .txt (matching "Text", "Vim Help File", "Adblock Filter List"), this produced flaky results.                                                            

  - convert HashSet to BTreeSet for deterministic alphabetical iteration
  - change regex to fancy-regex to support all heuristic patterns (backreferences, lookaround, possessive quantifiers)
  - Inlined the one \g<version> PCRE subroutine call in the Adblock Filter List heuristic (not supported by fancy-regex)
