### PR TITLE
add a listing for Markaby

### DIFF
--- a/definitions/languages.yml
+++ b/definitions/languages.yml
@@ -4551,6 +4551,12 @@ Mako:
   tm_scope: text.html.mako
   ace_mode: text
   language_id: 221
+Markaby:
+  type: markup
+  extensions:
+  - ".mab"
+  tm_scope: none
+  ace_mode: text
 Markdown:
   type: prose
   color: "#083fa1"


### PR DESCRIPTION
adds support for [Markaby](https://github.com/markaby/markaby), a Ruby-specific templating library.

I didn't add it to `group: Ruby`, because Haml and Slim (also Ruby-specific templating libraries) weren't in that group.